### PR TITLE
Output relative paths, not absolute

### DIFF
--- a/cmd/render-drawio/main.go
+++ b/cmd/render-drawio/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/racklet/render-drawio-action/pkg/render"
@@ -85,7 +84,5 @@ func run() error {
 	}
 
 	// Set the GH Action output
-	render.GitHubActionSetOutput("rendered-files", strings.Join(outputFiles, " "))
-
-	return nil
+	return render.GitHubActionSetFilesOutput("rendered-files", cfg.RootDir, outputFiles)
 }

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -243,3 +243,20 @@ func GitHubActionSetOutput(key, val string) {
 	zap.S().Infow("Setting Github Action output", key, val)
 	fmt.Printf("::set-output name=%s::%s\n", key, val)
 }
+
+func GitHubActionSetFilesOutput(key, rootDir string, files []string) error {
+	// Only run filepath.Rel if rootDir != ""
+	if len(rootDir) != 0 {
+		var err error
+		for i := range files {
+			// Make the file path relative to root dir
+			files[i], err = filepath.Rel(rootDir, files[i])
+			if err != nil {
+				return err
+			}
+		}
+	}
+	// Run the generic function
+	GitHubActionSetOutput(key, strings.Join(files, " "))
+	return nil
+}


### PR DESCRIPTION
Small improvement to be compatible with e.g. the `add-and-commit` action@twelho