### PR TITLE
Fix: Add Instructions for Storing GitHub Token in GitHub Actions Secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ A GitHub Action for rendering `*.drawio` files generated with [diagrams.net](htt
 
 ## Inputs
 
+### `GitHub Actions Secret`
+
+To enable GitHub Actions to push changes to your repository, you must provide it with a GitHub Personal Access Token. For those unfamiliar with the process, refer to the documentation to learn [how to generate a token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic). Once generated, securely store this token as a GitHub Actions secret. Consult the documentation for detailed instructions on [how to add and manage secrets](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions) within your repository's GitHub Actions settings.
+
 ### `formats`
 
 **Optional:** A comma-separated list of the formats to render. All supported formats: `svg,pdf,png,jpg`
@@ -108,6 +112,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      token: ${{ secrets.GH_TOKEN }}
     - name: Render .drawio files
       uses: docker://ghcr.io/racklet/render-drawio-action:v1
       with: # Showcasing the default values here


### PR DESCRIPTION
## Problem
The README initially did not instruct users to store their GitHub Token in GitHub Actions secrets. As a result, GitHub Actions did not have the required permissions to push the converted images back to the repository.

## Error
When running the workflow, the following error was encountered:

![error thrown](https://github.com/user-attachments/assets/f7b8b6a8-5c86-4e6b-b8a2-38ec4fbb8392)

## Fixes & Improvements
- Added instructions to the README, guiding users to store their GitHub Token in GitHub Actions secrets.
- Provided relevant documentation links to help users generate and store their GitHub Token.
- Updated the YAML workflow file to ensure that the GitHub Token is used when checking out the repository, allowing the workflow to push changes successfully.

This update ensures that the workflow runs smoothly without permission issues.

Follow is how the updated yml script looks like and works successfully.
![updated yml](https://github.com/user-attachments/assets/8ed16533-c90a-4434-bbf5-ba79b8249ecd)